### PR TITLE
chore: fix ComponentDataVariable test description typo

### DIFF
--- a/packages/core/test/specs/data_sources/model/ComponentDataVariable.ts
+++ b/packages/core/test/specs/data_sources/model/ComponentDataVariable.ts
@@ -247,7 +247,7 @@ describe('ComponentDataVariable', () => {
     expect(cmp.getInnerHTML()).toContain('NestedItemName1-UP');
   });
 
-  test('component initalizes and updates data on datarecord set object', () => {
+  test('component initializes and updates data on datarecord set object', () => {
     const dataSource = {
       id: 'setObject',
       records: [{ id: 'id1', content: 'Hello World', color: 'red' }],


### PR DESCRIPTION
## Summary
- fix typo in ComponentDataVariable test description

## Testing
- `pnpm --filter grapesjs test -- packages/core/test/specs/data_sources/model/ComponentDataVariable.ts`


------
https://chatgpt.com/codex/tasks/task_b_68a4b6b7e2848320bd822a614ea619e0