### PR TITLE
Fix DropLocationDeterminer move data reset

### DIFF
--- a/packages/core/src/utils/sorter/DropLocationDeterminer.ts
+++ b/packages/core/src/utils/sorter/DropLocationDeterminer.ts
@@ -74,7 +74,7 @@ export class DropLocationDeterminer<T, NodeType extends SortableTreeNode<T>> ext
     this.eventHandlers = options.eventHandlers;
     bindAll(this, 'endDrag', 'cancelDrag', 'recalculateTargetOnScroll', 'startSort', 'onDragStart', 'onMove');
 
-    this.restLastMoveData();
+    this.resetLastMoveData();
     this.rateLimiter = new RateLimiter<MouseEvent>(this.moveThreshold);
   }
 
@@ -140,7 +140,7 @@ export class DropLocationDeterminer<T, NodeType extends SortableTreeNode<T>> ext
     if (!targetNode || !hoveredNode) {
       this.triggerLegacyOnMoveCallback(mouseEvent, 0);
       this.triggerMoveEvent(mouseX, mouseY);
-      this.restLastMoveData();
+      this.resetLastMoveData();
 
       return;
     }
@@ -189,12 +189,15 @@ export class DropLocationDeterminer<T, NodeType extends SortableTreeNode<T>> ext
     }
   }
 
-  private restLastMoveData() {
+  private resetLastMoveData() {
     this.lastMoveData = {
       targetNode: undefined,
+      hoveredNode: undefined,
       index: undefined,
+      hoveredIndex: undefined,
       placement: undefined,
       mouseEvent: undefined,
+      placeholderDimensions: undefined,
     };
   }
 
@@ -310,7 +313,7 @@ export class DropLocationDeterminer<T, NodeType extends SortableTreeNode<T>> ext
     this.triggerOnDragEndEvent();
     this.eventHandlers.onEnd?.();
     this.eventHandlers.legacyOnEnd?.();
-    this.restLastMoveData();
+    this.resetLastMoveData();
     this.rateLimiter.clearTimeout();
   }
 

--- a/packages/core/test/specs/utils/DropLocationDeterminer.ts
+++ b/packages/core/test/specs/utils/DropLocationDeterminer.ts
@@ -1,0 +1,67 @@
+// @ts-nocheck
+import { DropLocationDeterminer } from '../../../src/utils/sorter/DropLocationDeterminer';
+import { SortableTreeNode } from '../../../src/utils/sorter/SortableTreeNode';
+import { DragDirection } from '../../../src/utils/sorter/types';
+
+class DummyNode extends SortableTreeNode<any> {
+  getChildren() {
+    return [];
+  }
+  getParent() {
+    return null;
+  }
+  addChildAt(node: any) {
+    return node;
+  }
+  removeChildAt() {}
+  indexOfChild() {
+    return 0;
+  }
+  canMove() {
+    return true;
+  }
+  get view() {
+    return undefined;
+  }
+  get element() {
+    return undefined;
+  }
+}
+
+describe('DropLocationDeterminer', () => {
+  test('resetLastMoveData clears all move data', () => {
+    const container = document.createElement('div');
+    const determiner = new DropLocationDeterminer({
+      em: {} as any,
+      treeClass: DummyNode,
+      containerContext: { container, itemSel: '', document },
+      positionOptions: {},
+      dragDirection: DragDirection.BothDirections,
+      eventHandlers: {},
+    });
+
+    determiner.lastMoveData = {
+      targetNode: {} as any,
+      hoveredNode: {} as any,
+      index: 1,
+      hoveredIndex: 2,
+      placement: 'before',
+      mouseEvent: new MouseEvent('mousemove'),
+      placeholderDimensions: {} as any,
+    };
+
+    // @ts-ignore - accessing private method for test
+    determiner.resetLastMoveData();
+
+    expect(determiner.lastMoveData).toEqual({
+      targetNode: undefined,
+      hoveredNode: undefined,
+      index: undefined,
+      hoveredIndex: undefined,
+      placement: undefined,
+      mouseEvent: undefined,
+      placeholderDimensions: undefined,
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- ensure DropLocationDeterminer.resetLastMoveData clears hovered node/index and placeholder dimensions
- rename restLastMoveData to resetLastMoveData and update references
- add unit test covering resetLastMoveData behavior

## Testing
- `pnpm --filter grapesjs test packages/core/test/specs/utils/DropLocationDeterminer.ts`


------
https://chatgpt.com/codex/tasks/task_b_68a4b819799c8320b53f442be063e137