### PR TITLE
fix: clarify scroll recalculation comment

### DIFF
--- a/packages/core/src/utils/sorter/DropLocationDeterminer.ts
+++ b/packages/core/src/utils/sorter/DropLocationDeterminer.ts
@@ -96,7 +96,7 @@ export class DropLocationDeterminer<T, NodeType extends SortableTreeNode<T>> ext
   /**
    * Triggers the `onMove` event.
    *
-   * This method is should be called when the user scrolls within the container, using the last recorded mouse event
+   * This method should be called when the user scrolls within the container, using the last recorded mouse event
    * to determine the new target.
    */
   recalculateTargetOnScroll(): void {


### PR DESCRIPTION
## Summary
- refine scroll recalculation comment in `DropLocationDeterminer`

## Testing
- `pnpm exec eslint packages/core/src/utils/sorter/DropLocationDeterminer.ts`
- `pnpm --filter grapesjs test -- --reporters=summary`


------
https://chatgpt.com/codex/tasks/task_b_68a4b9da2d04832091846f2b21d837a5